### PR TITLE
Update /usr/local/cuda refs to include cuda version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -165,9 +165,9 @@ build:rbe_linux_cuda11.1_nvcc_base --config=rbe_linux_cuda_base
 build:rbe_linux_cuda11.1_nvcc_base --action_env=TF_CUDA_VERSION=11
 build:rbe_linux_cuda11.1_nvcc_base --action_env=TF_CUDNN_VERSION=8
 build:rbe_linux_cuda11.1_nvcc_base --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.1"
-build:rbe_linux_cuda11.1_nvcc_base --action_env=LD_LIBRARY_PATH="/usr/local/cuda:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
+build:rbe_linux_cuda11.1_nvcc_base --action_env=LD_LIBRARY_PATH="/usr/local/cuda-11.1:/usr/local/cuda-11.1/lib64:/usr/local/cuda-11.1/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
 build:rbe_linux_cuda11.1_nvcc_base --action_env=GCC_HOST_COMPILER_PATH="/dt7/usr/bin/gcc"
-test:rbe_linux_cuda11.1_nvcc_base --test_env=LD_LIBRARY_PATH="/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda-11.1/lib64"
+test:rbe_linux_cuda11.1_nvcc_base --test_env=LD_LIBRARY_PATH="/usr/local/cuda-11.1/lib64:/usr/local/cuda-11.1/extras/CUPTI/lib64:/usr/local/cuda-11.1/lib64"
 build:rbe_linux_cuda11.1_nvcc_base --host_crosstool_top="@ubuntu18.04-gcc7_manylinux2010-cuda11.1-cudnn8-tensorrt7.2_config_cuda//crosstool:toolchain"
 build:rbe_linux_cuda11.1_nvcc_base --crosstool_top="@ubuntu18.04-gcc7_manylinux2010-cuda11.1-cudnn8-tensorrt7.2_config_cuda//crosstool:toolchain"
 build:rbe_linux_cuda11.1_nvcc_base --extra_toolchains="@ubuntu18.04-gcc7_manylinux2010-cuda11.1-cudnn8-tensorrt7.2_config_cuda//crosstool:toolchain-linux-x86_64"
@@ -190,7 +190,7 @@ build:rbe_linux_cuda11.4_nvcc_base --config=rbe_linux_cuda_base
 build:rbe_linux_cuda11.4_nvcc_base --action_env=TF_CUDA_VERSION=11
 build:rbe_linux_cuda11.4_nvcc_base --action_env=TF_CUDNN_VERSION=8
 build:rbe_linux_cuda11.4_nvcc_base --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.4"
-build:rbe_linux_cuda11.4_nvcc_base --action_env=LD_LIBRARY_PATH="/usr/local/cuda:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
+build:rbe_linux_cuda11.4_nvcc_base --action_env=LD_LIBRARY_PATH="/usr/local/cuda-11.4:/usr/local/cuda-11.4/lib64:/usr/local/cuda-11.4/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
 build:rbe_linux_cuda11.4_nvcc_base --action_env=GCC_HOST_COMPILER_PATH="/dt7/usr/bin/gcc"
 build:rbe_linux_cuda11.4_nvcc_base --host_crosstool_top="@ubuntu18.04-gcc7_manylinux2010-cuda11.4-cudnn8.2-tensorrt7.2_config_cuda//crosstool:toolchain"
 build:rbe_linux_cuda11.4_nvcc_base --crosstool_top="@ubuntu18.04-gcc7_manylinux2010-cuda11.4-cudnn8.2-tensorrt7.2_config_cuda//crosstool:toolchain"
@@ -214,7 +214,7 @@ build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base --config=rbe_linux_cuda_base
 build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --action_env=TF_CUDA_VERSION=11
 build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --action_env=TF_CUDNN_VERSION=8.0.5
 build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --action_env=CUDA_TOOLKIT_PATH="/usr/local/cuda-11.4"
-build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --action_env=LD_LIBRARY_PATH="/usr/local/cuda:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
+build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --action_env=LD_LIBRARY_PATH="/usr/local/cuda-11.4:/usr/local/cuda-11.4/lib64:/usr/local/cuda-11.4/extras/CUPTI/lib64:/usr/local/tensorrt/lib"
 build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --action_env=GCC_HOST_COMPILER_PATH="/dt7/usr/bin/gcc"
 build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --host_crosstool_top="@ubuntu18.04-gcc7_manylinux2010-cuda11.4-cudnn8.0.5-tensorrt7.2_config_cuda//crosstool:toolchain"
 build:rbe_linux_cuda11.4_cudnn8.0.5_nvcc_base  --crosstool_top="@ubuntu18.04-gcc7_manylinux2010-cuda11.4-cudnn8.0.5-tensorrt7.2_config_cuda//crosstool:toolchain"


### PR DESCRIPTION
This prevents the wrong CUDA version (e.g. when `/usr/local/cuda` points to a different version than `/usr/local/cuda-11.1`) from being used by Bazel build.